### PR TITLE
Fix incorrect default value of rbenv_path

### DIFF
--- a/lib/capistrano/tasks/ndenv.rake
+++ b/lib/capistrano/tasks/ndenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       ndenv_path ||= if fetch(:ndenv_type, :user) == :system
         "/usr/local/ndenv"
       else
-        "$HOME/ndenv"
+        "$HOME/.ndenv"
       end
     }
 


### PR DESCRIPTION
Fix bug by https://github.com/l8nite/capistrano-ndenv/pull/2 

```
$ bundle exec cap development deploy:check

0:00 ndenv:validate
      ERROR ndenv: v9.4.0 is not installed or not found in $HOME/ndenv/versions/v9.4.0
```